### PR TITLE
Create configurable multilingual book template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "how-to-love"]
-	path = how-to-love
-	url = https://github.com/cholf5/how-to-love

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# mdbook-multilang-site – Agent Guide
+
+This repository hosts a static multilingual book template. It is designed so that all customisable data lives in `config/site.config.json` and Markdown chapters under `content/<language-code>/`. When editing or extending the project, keep the following guidelines in mind.
+
+## Repository layout
+
+- `index.html` – loads configuration, SEO metadata, and renders the shell.
+- `assets/styles.css` – global styling. Prefer CSS variables and keep dark-mode support intact.
+- `assets/scripts.js` – vanilla JavaScript that reads the config, performs runtime rendering, updates meta tags, and handles navigation.
+- `config/site.config.json` – single source of truth for site metadata, languages, navigation, and SEO options.
+- `content/` – Markdown sources organised by language code. Filenames should match the references in the config.
+- `tools/generate-sitemap.mjs` – Node script that regenerates `sitemap.xml` and `robots.txt` using the config.
+- `package.json` – exposes `npm run generate:sitemap` for the script above.
+
+## Working conventions
+
+- **Always update the config** instead of hardcoding metadata. Any new site-wide parameter should be added to `config/site.config.json` and consumed via `assets/scripts.js`.
+- **Keep SEO features functional**: if you modify how pages are rendered, ensure canonical URLs, alternate language links, Open Graph/Twitter tags, and JSON-LD continue to be produced.
+- **Language awareness**: guard features so they degrade gracefully if a language lacks a chapter file. Do not assume every chapter exists in every language.
+- **Styling**: use CSS custom properties and keep the layout responsive (desktop + mobile). Dark-mode tokens are already defined; extend them if you introduce new colour variables.
+- **JavaScript**: stay with framework-free ES modules / IIFE style. Avoid bundler-specific syntax. Do not introduce blocking synchronous XHR.
+- **Scripts**: If you add files that depend on the config (e.g. feeds, manifests), update `tools/generate-sitemap.mjs` or provide a similar utility so generated artifacts stay in sync.
+
+## Required checks
+
+After changing configuration, Markdown, or SEO-affecting files, rerun:
+
+```bash
+npm run generate:sitemap
+```
+
+Include the regenerated `sitemap.xml` and `robots.txt` in commits.
+

--- a/README.md
+++ b/README.md
@@ -1,54 +1,155 @@
-
 # mdbook-multilang-site
 
-📚 A static website template for multilingual books powered by Markdown.  
-只需编写 Markdown，就能发布支持多语言的在线书籍网站。
+A ready-to-ship static website template for publishing multilingual books written in Markdown. All project metadata, navigation, and localisation details are driven by a single JSON configuration file so that you only have to edit Markdown files and update one config to launch your book.
+
+![Screenshot of the multilingual book template](images/demo.webp)
 
 ---
 
-## ✨ Features
-- Write your book in **Markdown**
-- Built-in **multi-language** support (`en`, `zh-cn`, `zh-tw`, …)
-- Ready-to-use **static site** (no backend required)
-- Customizable theme, logo, and assets
+## 🌟 Highlights
+
+- **Markdown-first authoring** – store your chapters under `content/<language-code>/`.
+- **Single source of truth** – configure title, languages, navigation, SEO, and footer in `config/site.config.json`.
+- **SEO aware** – automatic canonical URLs, alternate language tags, JSON-LD, sitemap, and robots.txt generation.
+- **No build tooling required** – the runtime uses [Marked](https://marked.js.org/) to render Markdown in the browser.
+- **Upgradeable** – reuse the template through forking or as a Git submodule.
 
 ---
 
-## 🚀 Quick Start
-1. Clone this repo  
+## 📁 Project structure
+
+```
+.
+├── assets/                 # CSS and JavaScript that power the template UI
+├── config/site.config.json # Central configuration for metadata, languages, and chapters
+├── content/                # Markdown sources grouped by language code
+├── images/                 # Shared static assets (favicons, social images, etc.)
+├── index.html              # Entry point that loads the configuration at runtime
+├── robots.txt              # Generated from the config (kept in sync via a script)
+├── sitemap.xml             # Generated XML sitemap for SEO
+└── tools/generate-sitemap.mjs  # Utility script to regenerate sitemap & robots.txt
+```
+
+---
+
+## 🚀 Getting started
+
+1. **Install Node.js** (18+ recommended) so you can run the helper script.
+2. **Clone or scaffold** this repository (see [Upgrade & reuse](#-upgrade--reuse) for guidance).
+3. **Update the configuration** in [`config/site.config.json`](config/site.config.json):
+   - `site.title`, `site.tagline`, `site.description`, `site.author`, `site.baseUrl`
+   - `languages` (code, label, locale, direction)
+   - `chapters` (chapter IDs, translated titles, and per-language Markdown filenames)
+   - `seo` settings such as keywords, Twitter handle, and social sharing image
+4. **Replace the Markdown files** in `content/<language-code>/` with your chapters.
+5. **Refresh the sitemap and robots.txt** after any change to the config or Markdown:
    ```bash
-   git clone https://github.com/cholf5/mdbook-multilang-site.git
-   cd mdbook-multilang-site
-    ```
+   npm run generate:sitemap
+   ```
+6. **Preview locally** by opening `index.html` directly in your browser or serving the folder with any static file server.
+7. **Deploy** by uploading the repository (or the subset of files you need) to any static hosting platform (GitHub Pages, Netlify, Vercel, S3, Cloudflare Pages, etc.).
 
-2. Edit your book in the `book/` folder
-
-   * `book/en/` → English chapters
-   * `book/zh-cn/` → 简体中文章节
-   * `book/zh-tw/` → 繁體中文章节
-
-3. Update `book/chapters.json` to configure chapter order.
-
-4. Open `index.html` in your browser 🚀
+> **Tip:** Keep filenames consistent across languages (for example `introduction.md` in each language folder) so the navigation stays aligned.
 
 ---
 
-## 🛠 Customization
+## 🔧 Configuration reference (`config/site.config.json`)
 
-* Change site title in `index.html`
-* Replace `images/logo-banner.png` with your own logo
-* Modify styles in `assets/styles.css`
+| Key | Description |
+| --- | --- |
+| `site.title` | Title displayed in the header and browser tab. |
+| `site.tagline` | Short description that appears below the title. |
+| `site.description` | Default meta description used when a chapter does not define one. |
+| `site.author` | Author name injected into JSON-LD structured data. |
+| `site.baseUrl` | Public URL where the book will be hosted. Used to generate canonical URLs, sitemaps, and social images – **must be updated before deploying**. |
+| `site.footer` | Footer text. Supports `{year}` placeholder for automatic year substitution. |
+| `site.logo` | Path to the logo or cover image. |
+| `site.contentsLabel` / `site.languageLabel` | Optional language-specific labels for UI strings. |
+| `languages[]` | List of supported languages. Provide `code`, user-facing `label`, optional `locale`, and `direction` (e.g. `rtl`). |
+| `chapters[]` | Ordered chapter definitions. Each chapter needs a stable `id`, translated `titles`, optional `description`, and per-language Markdown filenames under `files`. |
+| `links[]` | Optional primary navigation links (e.g. GitHub repo, community). |
+| `seo.keywords` | Array of keywords joined into the meta keywords tag. |
+| `seo.socialImage` | Absolute or relative URL for Open Graph & Twitter cards. |
+| `seo.twitter` | Twitter handle (with or without `@`) for card attribution. |
+
+Whenever you modify this file or add new Markdown chapters, rerun `npm run generate:sitemap` so search engines receive the updated canonical links and sitemap.
 
 ---
 
-## 📖 Example
+## ✍️ Adding a new language
 
-👉 [Live Demo](https://cholf5.com/how-to-love/)
-👉 Screenshot:
-![screenshot](images/demo.webp)
+1. Add an entry to `languages` with a unique `code` (e.g. `fr`), label, locale, and direction.
+2. Duplicate the Markdown files from an existing language into `content/<new-code>/` and translate them. Only chapters present in both the config and filesystem will appear.
+3. If you want custom UI labels (such as "Contents"), extend `site.contentsLabel` and `site.languageLabel` with the new language code.
+4. Run `npm run generate:sitemap` to include the new language in `sitemap.xml` and `robots.txt`.
 
 ---
 
-## 📜 License
+## ➕ Adding a chapter
+
+1. Create Markdown files under each language folder (e.g. `content/en/part-03.md`).
+2. Append a new object to the `chapters` array with:
+   - `id`: URL-safe identifier (used in query parameters and analytics).
+   - `titles`: map of language code to display title.
+   - `files`: map of language code to Markdown filename.
+   - Optional `description`: shown below the chapter title and reused for meta descriptions.
+3. Rerun `npm run generate:sitemap`.
+
+---
+
+## 🔍 SEO checklist
+
+- Set a meaningful `site.baseUrl` that matches your production domain.
+- Provide descriptive `site.description` and per-chapter `description` values for richer snippets.
+- Supply a `seo.socialImage` (ideal size 1200×630) and ensure the file exists.
+- Use descriptive alt text within Markdown images for accessibility and search.
+- Keep `robots.txt` and `sitemap.xml` in sync by running `npm run generate:sitemap` whenever content changes.
+- Consider uploading the sitemap URL to Google Search Console and Bing Webmaster Tools after deployment.
+
+---
+
+## ♻️ Upgrade & reuse
+
+There are two recommended strategies for using this template in your own projects:
+
+### 1. **Template / fork workflow (recommended)**
+
+- Click **“Use this template”** on GitHub or fork the repository.
+- Replace the Markdown and configuration files with your content.
+- Pull upstream changes periodically:
+  ```bash
+  git remote add upstream https://github.com/cholf5/mdbook-multilang-site.git
+  git fetch upstream
+  git merge upstream/main
+  ```
+- Resolve any merge conflicts in your Markdown or config, then regenerate the sitemap.
+
+This approach keeps your book self-contained while still allowing you to receive template improvements by merging upstream commits.
+
+### 2. **Git submodule workflow**
+
+- Add this repository as a submodule inside your book project:
+  ```bash
+  git submodule add https://github.com/cholf5/mdbook-multilang-site.git templates/mdbook-multilang-site
+  ```
+- Store your Markdown and config alongside the submodule or inside it (if you are comfortable committing inside the submodule).
+- When the template updates, run `git submodule update --remote` from your parent repository and re-run `npm run generate:sitemap`.
+
+The submodule route is useful if you manage multiple books from a single monorepo or want to keep template updates isolated.
+
+> Regardless of the strategy, keep your `config/site.config.json` under version control and document any customisations so you can reconcile them when merging upstream changes.
+
+---
+
+## 🧠 Troubleshooting
+
+- **Nothing renders** – check the browser console for JSON parse errors (malformed `site.config.json` is the usual culprit).
+- **Chapter missing in one language** – ensure the corresponding Markdown file exists and is referenced in `chapters[].files`.
+- **Incorrect canonical URLs** – confirm that `site.baseUrl` includes the full domain and trailing slash, then run `npm run generate:sitemap`.
+- **Scripts blocked by CSP** – if you enforce a strict Content Security Policy, self-host `marked.min.js` instead of loading it from the CDN.
+
+---
+
+## 📄 License
 
 MIT License

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -1,0 +1,392 @@
+(async function initMultilangBook() {
+  const config = await fetchJson('config/site.config.json');
+  const languages = buildMap(config.languages, (lang) => lang.code);
+  const chapters = buildMap(config.chapters, (chapter) => chapter.id);
+  const orderedChapterIds = config.chapters.map((chapter) => chapter.id);
+
+  const state = {
+    language: resolveLanguage(languages, config.site.defaultLanguage),
+    chapterId: orderedChapterIds[0] || null,
+  };
+
+  const url = new URL(window.location.href);
+  const requestedLanguage = url.searchParams.get('lang');
+  const requestedChapter = url.searchParams.get('chapter');
+
+  if (requestedLanguage && languages.has(requestedLanguage)) {
+    state.language = requestedLanguage;
+  }
+
+  if (requestedChapter && chapters.has(requestedChapter)) {
+    state.chapterId = requestedChapter;
+  }
+
+  const root = document.documentElement;
+  const siteTitleEl = document.getElementById('site-title');
+  const siteTaglineEl = document.getElementById('site-tagline');
+  const siteLogoEl = document.getElementById('site-logo');
+  const navLinksEl = document.getElementById('site-links');
+  const languageSwitcherEl = document.getElementById('language-switcher');
+  const chapterListEl = document.getElementById('chapter-list');
+  const chapterTitleEl = document.getElementById('chapter-title');
+  const chapterDescriptionEl = document.getElementById('chapter-description');
+  const chapterContentEl = document.getElementById('chapter-content');
+  const footerTextEl = document.getElementById('footer-text');
+  const chaptersLabelEl = document.getElementById('chapters-label');
+
+  if (siteTitleEl) siteTitleEl.textContent = config.site.title;
+  if (siteTaglineEl) siteTaglineEl.textContent = config.site.tagline;
+  if (siteLogoEl && config.site.logo) {
+    siteLogoEl.src = config.site.logo;
+  }
+
+  if (chaptersLabelEl) {
+    chaptersLabelEl.textContent = pickLocalizedLabel(
+      config.site.contentsLabel,
+      state.language,
+      'Contents'
+    );
+  }
+
+  if (footerTextEl) {
+    const currentYear = new Date().getFullYear();
+    footerTextEl.textContent = config.site.footer.replace('{year}', currentYear.toString());
+  }
+
+  renderLinks(config.links || [], navLinksEl);
+  renderLanguageSwitcher();
+  await setLanguage(state.language);
+
+  async function setLanguage(code) {
+    const nextLanguage = resolveLanguage(languages, code);
+    state.language = nextLanguage;
+    const langMeta = languages.get(state.language);
+
+    if (langMeta) {
+      root.lang = langMeta.locale || langMeta.code;
+      root.dir = langMeta.direction || 'ltr';
+    }
+
+    if (chaptersLabelEl) {
+      chaptersLabelEl.textContent = pickLocalizedLabel(
+        config.site.contentsLabel,
+        state.language,
+        chaptersLabelEl.textContent
+      );
+    }
+
+    renderLanguageSwitcher();
+
+    const fallbackChapterId = findFirstChapterWithLanguage(state.language);
+    if (fallbackChapterId) {
+      if (!state.chapterId || !chapterHasLanguage(state.chapterId, state.language)) {
+        state.chapterId = fallbackChapterId;
+      }
+    }
+
+    renderChapters();
+    await loadChapter(state.chapterId);
+  }
+
+  function renderLanguageSwitcher() {
+    if (!languageSwitcherEl) return;
+    languageSwitcherEl.innerHTML = '';
+
+    const label = document.createElement('span');
+    label.className = 'language-switcher-label';
+    const labelText = pickLocalizedLabel(config.site.languageLabel, state.language, 'Languages');
+    label.textContent = labelText;
+    languageSwitcherEl.setAttribute('aria-label', labelText);
+    languageSwitcherEl.appendChild(label);
+
+    (config.languages || []).forEach((lang) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'language-button';
+      button.textContent = lang.label || lang.code;
+      button.setAttribute('aria-pressed', state.language === lang.code ? 'true' : 'false');
+      button.setAttribute('aria-current', state.language === lang.code ? 'true' : 'false');
+      button.addEventListener('click', () => {
+        if (state.language !== lang.code) {
+          setLanguage(lang.code);
+        }
+      });
+      languageSwitcherEl.appendChild(button);
+    });
+  }
+
+  function renderLinks(links, container) {
+    if (!container) return;
+    container.innerHTML = '';
+    links.forEach((link) => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = link.url;
+      a.textContent = link.label;
+      a.rel = 'noopener';
+      a.target = link.target || '_blank';
+      li.appendChild(a);
+      container.appendChild(li);
+    });
+  }
+
+  function renderChapters() {
+    if (!chapterListEl) return;
+    chapterListEl.innerHTML = '';
+    orderedChapterIds.forEach((chapterId) => {
+      if (!chapterHasLanguage(chapterId, state.language)) {
+        return;
+      }
+      const chapter = chapters.get(chapterId);
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'chapter-button';
+      button.textContent = pickLocalizedLabel(chapter.titles, state.language, chapterId);
+      button.setAttribute('aria-current', state.chapterId === chapterId ? 'true' : 'false');
+      button.addEventListener('click', async () => {
+        if (state.chapterId !== chapterId) {
+          state.chapterId = chapterId;
+          updateUrl();
+          updateCanonical();
+          await loadChapter(chapterId);
+          renderChapters();
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      });
+      li.appendChild(button);
+      chapterListEl.appendChild(li);
+    });
+  }
+
+  function chapterHasLanguage(chapterId, languageCode) {
+    const chapter = chapters.get(chapterId);
+    if (!chapter) return false;
+    return Boolean(chapter.files && chapter.files[languageCode]);
+  }
+
+  function findFirstChapterWithLanguage(languageCode) {
+    return orderedChapterIds.find((chapterId) => chapterHasLanguage(chapterId, languageCode)) || null;
+  }
+
+  async function loadChapter(chapterId) {
+    const chapter = chapters.get(chapterId);
+    if (!chapter) {
+      chapterTitleEl.textContent = '';
+      chapterDescriptionEl.textContent = '';
+      chapterContentEl.innerHTML = '<p>No chapter selected.</p>';
+      return;
+    }
+
+    const title = pickLocalizedLabel(chapter.titles, state.language, chapterId);
+    const description = chapter.description || config.site.description;
+    const fileName = chapter.files?.[state.language];
+
+    if (!fileName) {
+      chapterTitleEl.textContent = title;
+      chapterDescriptionEl.textContent = description;
+      chapterContentEl.innerHTML = '<p>This chapter is not available in the selected language yet.</p>';
+      return;
+    }
+
+    chapterTitleEl.textContent = title;
+    chapterDescriptionEl.textContent = description;
+
+    const path = `content/${state.language}/${fileName}`;
+    try {
+      const markdown = await fetchText(path);
+      const html = marked.parse(markdown, { mangle: false, headerIds: true });
+      chapterContentEl.innerHTML = html;
+      enhanceExternalLinks(chapterContentEl);
+    } catch (error) {
+      chapterContentEl.innerHTML = `<p class="error">Failed to load <code>${path}</code>: ${error.message}</p>`;
+    }
+
+    updateMeta(title, description);
+    updateUrl();
+    updateCanonical();
+    updateStructuredData(title, description);
+    renderAlternateLinks();
+  }
+
+  function updateUrl() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', state.language);
+    url.searchParams.set('chapter', state.chapterId);
+    history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+  }
+
+  function updateCanonical() {
+    const canonicalLink = getOrCreateLink('canonical');
+    canonicalLink.setAttribute('href', buildPageUrl(state.language, state.chapterId));
+  }
+
+  function renderAlternateLinks() {
+    removeExistingAlternateLinks();
+    (config.languages || []).forEach((lang) => {
+      const link = document.createElement('link');
+      link.rel = 'alternate';
+      link.hreflang = lang.locale || lang.code;
+      link.href = buildPageUrl(lang.code, state.chapterId);
+      document.head.appendChild(link);
+    });
+  }
+
+  function removeExistingAlternateLinks() {
+    document.querySelectorAll('link[rel="alternate"]').forEach((link) => {
+      link.remove();
+    });
+  }
+
+  function updateMeta(title, description) {
+    document.title = `${title} · ${config.site.title}`;
+    setMeta('description', description);
+    const keywords = (config.seo?.keywords || []).join(', ');
+    if (keywords) {
+      setMeta('keywords', keywords);
+    }
+    setPropertyMeta('og:title', title);
+    setPropertyMeta('og:description', description);
+    setPropertyMeta('og:type', 'book');
+    const socialImage = config.seo?.socialImage;
+    if (socialImage) {
+      setPropertyMeta('og:image', resolveAssetUrl(socialImage));
+      setNameMeta('twitter:image', resolveAssetUrl(socialImage));
+    }
+    setNameMeta('twitter:card', 'summary_large_image');
+    setNameMeta('twitter:title', title);
+    setNameMeta('twitter:description', description);
+    if (config.seo?.twitter) {
+      setNameMeta('twitter:creator', config.seo.twitter);
+      setNameMeta('twitter:site', config.seo.twitter);
+    }
+  }
+
+  function updateStructuredData(title, description) {
+    const script = document.getElementById('structured-data');
+    if (!script) return;
+    const payload = {
+      '@context': 'https://schema.org',
+      '@type': 'Book',
+      name: title,
+      inLanguage: config.languages.map((lang) => lang.locale || lang.code),
+      url: buildPageUrl(state.language, state.chapterId),
+      author: {
+        '@type': 'Person',
+        name: config.site.author,
+      },
+      description,
+    };
+    script.textContent = JSON.stringify(payload, null, 2);
+  }
+
+  function buildPageUrl(languageCode, chapterId) {
+    const base = config.site.baseUrl || window.location.href;
+    try {
+      const url = new URL(base);
+      url.searchParams.set('lang', languageCode);
+      if (chapterId) {
+        url.searchParams.set('chapter', chapterId);
+      }
+      return url.toString();
+    } catch (error) {
+      const query = new URLSearchParams({ lang: languageCode, chapter: chapterId }).toString();
+      return `${base.replace(/[#?].*$/, '')}?${query}`;
+    }
+  }
+
+  function setMeta(name, content) {
+    const meta = getOrCreateMeta(`meta[name="${name}"]`, { name });
+    meta.setAttribute('content', content);
+  }
+
+  function setNameMeta(name, content) {
+    const meta = getOrCreateMeta(`meta[name="${name}"]`, { name });
+    meta.setAttribute('content', content);
+  }
+
+  function setPropertyMeta(property, content) {
+    const meta = getOrCreateMeta(`meta[property="${property}"]`, { property });
+    meta.setAttribute('content', content);
+  }
+
+  function getOrCreateMeta(selector, attributes) {
+    let meta = document.head.querySelector(selector);
+    if (!meta) {
+      meta = document.createElement('meta');
+      Object.entries(attributes).forEach(([key, value]) => meta.setAttribute(key, value));
+      document.head.appendChild(meta);
+    }
+    return meta;
+  }
+
+  function getOrCreateLink(rel) {
+    let link = document.head.querySelector(`link[rel="${rel}"]`);
+    if (!link) {
+      link = document.createElement('link');
+      link.setAttribute('rel', rel);
+      document.head.appendChild(link);
+    }
+    return link;
+  }
+
+  function pickLocalizedLabel(map, languageCode, fallback) {
+    if (!map) return fallback;
+    return map[languageCode] || map.default || fallback;
+  }
+
+  function resolveLanguage(map, requested) {
+    if (requested && map.has(requested)) {
+      return requested;
+    }
+    return map.keys().next().value;
+  }
+
+  function buildMap(list, keySelector) {
+    const map = new Map();
+    (list || []).forEach((item) => {
+      const key = keySelector(item);
+      if (key) {
+        map.set(key, item);
+      }
+    });
+    return map;
+  }
+
+  async function fetchJson(path) {
+    const response = await fetch(path);
+    if (!response.ok) {
+      throw new Error(`Failed to load ${path}: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async function fetchText(path) {
+    const response = await fetch(path);
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    return response.text();
+  }
+
+  function enhanceExternalLinks(container) {
+    if (!container) return;
+    container.querySelectorAll('a[href^="http"]').forEach((anchor) => {
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener noreferrer');
+    });
+  }
+
+  function resolveAssetUrl(path) {
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+    const baseUrl = config.site.baseUrl || window.location.origin + window.location.pathname;
+    try {
+      const url = new URL(path, baseUrl);
+      return url.toString();
+    } catch (error) {
+      return path;
+    }
+  }
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,259 @@
+:root {
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --border: #e5e7eb;
+  --text: #0f172a;
+  --text-secondary: #475569;
+  --accent: #6366f1;
+  --accent-contrast: #ffffff;
+  --radius: 16px;
+  --transition: 180ms ease;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover,
+a:focus {
+  color: #4f46e5;
+}
+
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 5vw;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(8px);
+}
+
+.site-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+
+.site-nav ul,
+.chapter-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.site-nav li a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.site-nav li a:hover,
+.site-nav li a:focus {
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent);
+}
+
+.language-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.language-switcher-label {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  align-self: center;
+  margin-right: 0.35rem;
+}
+
+.language-button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.language-button[aria-current="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 2.5rem;
+  padding: 2.5rem 5vw;
+}
+
+.sidebar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  position: sticky;
+  top: 6.5rem;
+  max-height: calc(100vh - 8rem);
+  overflow-y: auto;
+}
+
+.sidebar-title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.chapter-list {
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chapter-button {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  text-align: left;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.chapter-button:hover,
+.chapter-button:focus {
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--accent);
+}
+
+.chapter-button[aria-current="true"] {
+  border-color: var(--accent);
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.content {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+  min-height: 60vh;
+}
+
+.chapter-meta h2 {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+}
+
+.chapter-description {
+  margin-top: 0;
+  color: var(--text-secondary);
+}
+
+.chapter-content h1,
+.chapter-content h2,
+.chapter-content h3,
+.chapter-content h4 {
+  color: var(--text);
+}
+
+.chapter-content pre {
+  background: #1f2937;
+  color: #f8fafc;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.chapter-content code {
+  font-family: "Fira Code", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: rgba(99, 102, 241, 0.12);
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+}
+
+.chapter-content img {
+  max-width: 100%;
+  border-radius: 12px;
+}
+
+.site-footer {
+  padding: 2rem 5vw 3rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    top: auto;
+    max-height: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --surface: #111827;
+    --border: #1f2937;
+    --text: #f8fafc;
+    --text-secondary: #cbd5f5;
+    --accent: #8b5cf6;
+  }
+
+  .site-logo {
+    border-color: var(--border);
+    background: var(--surface);
+  }
+
+  .chapter-content code {
+    background: rgba(139, 92, 246, 0.25);
+  }
+}

--- a/config/site.config.json
+++ b/config/site.config.json
@@ -1,0 +1,83 @@
+{
+  "site": {
+    "title": "How to Love",
+    "tagline": "A multilingual book template built with Markdown",
+    "description": "An opinionated template for publishing a multilingual book as a static website. Replace the Markdown files with your own chapters and update this config to launch your book.",
+    "author": "Your Name",
+    "baseUrl": "https://example.com/how-to-love/",
+    "defaultLanguage": "en",
+    "footer": "© {year} Your Name. Released under the MIT License.",
+    "logo": "images/demo.webp",
+    "contentsLabel": {
+      "en": "Contents",
+      "zh-cn": "目录",
+      "zh-tw": "目錄"
+    },
+    "languageLabel": {
+      "en": "Languages",
+      "zh-cn": "语言",
+      "zh-tw": "語言"
+    }
+  },
+  "languages": [
+    {
+      "code": "en",
+      "label": "English",
+      "locale": "en",
+      "direction": "ltr"
+    },
+    {
+      "code": "zh-cn",
+      "label": "简体中文",
+      "locale": "zh-CN",
+      "direction": "ltr"
+    },
+    {
+      "code": "zh-tw",
+      "label": "繁體中文",
+      "locale": "zh-TW",
+      "direction": "ltr"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "introduction",
+      "titles": {
+        "en": "Introduction",
+        "zh-cn": "简介",
+        "zh-tw": "簡介"
+      },
+      "files": {
+        "en": "introduction.md",
+        "zh-cn": "introduction.md",
+        "zh-tw": "introduction.md"
+      },
+      "description": "Start here to learn how the template is organised."
+    },
+    {
+      "id": "writing-with-markdown",
+      "titles": {
+        "en": "Writing with Markdown",
+        "zh-cn": "用 Markdown 写作",
+        "zh-tw": "用 Markdown 寫作"
+      },
+      "files": {
+        "en": "writing-with-markdown.md",
+        "zh-cn": "writing-with-markdown.md",
+        "zh-tw": "writing-with-markdown.md"
+      },
+      "description": "Replace these placeholder chapters with the content of your book."
+    }
+  ],
+  "links": [
+    {
+      "label": "GitHub",
+      "url": "https://github.com/cholf5/mdbook-multilang-site"
+    }
+  ],
+  "seo": {
+    "keywords": ["markdown book", "multilingual book", "static site template"],
+    "socialImage": "images/demo.webp",
+    "twitter": "@example"
+  }
+}

--- a/content/en/introduction.md
+++ b/content/en/introduction.md
@@ -1,0 +1,7 @@
+# Welcome
+
+This is a starter chapter for the multilingual book template. Replace the content with your own story.
+
+- Update the metadata inside `config/site.config.json`
+- Create Markdown files for each language under `content/<language-code>/`
+- Run `npm run generate:sitemap` after editing your chapters to keep SEO metadata fresh.

--- a/content/en/writing-with-markdown.md
+++ b/content/en/writing-with-markdown.md
@@ -1,0 +1,9 @@
+# Writing with Markdown
+
+This template renders Markdown on the client side using [Marked](https://marked.js.org/).
+
+1. Keep filenames consistent across languages so that navigation stays in sync.
+2. Use relative links when referencing other chapters (for example `../en/writing-with-markdown.md`).
+3. Embed images by placing them in the `images/` folder and referencing them with standard Markdown syntax.
+
+> Tip: store reusable text like disclaimers or author notes in partial Markdown files and include them with a build step if needed.

--- a/content/zh-cn/introduction.md
+++ b/content/zh-cn/introduction.md
@@ -1,0 +1,7 @@
+# 欢迎
+
+这是一个多语言书籍模板的示例章节。把这里的内容替换成你的故事吧。
+
+- 修改 `config/site.config.json` 中的元数据
+- 在 `content/<language-code>/` 下为每种语言创建 Markdown 文件
+- 更新章节后执行 `npm run generate:sitemap`，保持 SEO 数据最新

--- a/content/zh-cn/writing-with-markdown.md
+++ b/content/zh-cn/writing-with-markdown.md
@@ -1,0 +1,9 @@
+# 用 Markdown 写作
+
+此模板在客户端通过 [Marked](https://marked.js.org/) 渲染 Markdown 内容。
+
+1. 为了保持导航同步，请确保不同语言的文件名一致。
+2. 引用其他章节时使用相对路径（例如 `../en/writing-with-markdown.md`）。
+3. 将图片放在 `images/` 目录，并用标准 Markdown 语法引用。
+
+> 小贴士：如果需要复用文本（如声明、作者寄语），可以把它们放在独立的 Markdown 文件中，通过构建脚本合并。

--- a/content/zh-tw/introduction.md
+++ b/content/zh-tw/introduction.md
@@ -1,0 +1,7 @@
+# 歡迎
+
+這是一個多語言書籍模板的示例章節，請把內容換成你的作品。
+
+- 在 `config/site.config.json` 中調整站點資訊
+- 於 `content/<language-code>/` 目錄為每種語言新增 Markdown 檔案
+- 變更章節後執行 `npm run generate:sitemap`，維持 SEO 資料最新

--- a/content/zh-tw/writing-with-markdown.md
+++ b/content/zh-tw/writing-with-markdown.md
@@ -1,0 +1,9 @@
+# 用 Markdown 寫作
+
+此模板在瀏覽器端透過 [Marked](https://marked.js.org/) 轉換 Markdown。
+
+1. 請確保不同語言的檔名一致，方便同步導覽。
+2. 參考其他章節時請使用相對路徑（例如 `../en/writing-with-markdown.md`）。
+3. 將圖片放到 `images/` 目錄並使用標準 Markdown 語法插入。
+
+> 小提醒：若需要重複使用聲明或作者序，可以額外建立 Markdown 檔案並在建置時匯入。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Multilingual Book Template</title>
+    <meta name="description" content="Publish a multilingual book with Markdown and zero build tooling." />
+    <meta name="keywords" content="book, markdown, multilingual" />
+    <link rel="canonical" href="https://example.com/how-to-love/" />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="icon" type="image/png" href="images/demo.webp" />
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" integrity="sha384-P4RduCMsZ/HwtaFcIMc0HRzyIeWAtKvTPQrOAHJYjWCceLbsRKPrH2mQb23jArty" crossorigin="anonymous"></script>
+    <script defer src="assets/scripts.js"></script>
+    <script type="application/ld+json" id="structured-data">
+      {
+        "@context": "https://schema.org",
+        "@type": "Book",
+        "name": "Multilingual Book Template",
+        "inLanguage": ["en"],
+        "author": {
+          "@type": "Person",
+          "name": "Your Name"
+        },
+        "url": "https://example.com/how-to-love/"
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-meta">
+        <img id="site-logo" class="site-logo" alt="Site logo" />
+        <div>
+          <h1 id="site-title">Multilingual Book Template</h1>
+          <p id="site-tagline">Publish a multilingual book with Markdown.</p>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <ul id="site-links"></ul>
+      </nav>
+      <div class="language-switcher" id="language-switcher" aria-label="Languages"></div>
+    </header>
+
+    <main class="layout">
+      <aside class="sidebar" aria-label="Chapters">
+        <h2 class="sidebar-title" id="chapters-label">Contents</h2>
+        <ul id="chapter-list" class="chapter-list"></ul>
+      </aside>
+      <article class="content" aria-live="polite">
+        <div class="chapter-meta">
+          <h2 id="chapter-title"></h2>
+          <p id="chapter-description" class="chapter-description"></p>
+        </div>
+        <div id="chapter-content" class="chapter-content"></div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <p id="footer-text">© 2024 Your Name. Released under the MIT License.</p>
+    </footer>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mdbook-multilang-site-template",
+  "version": "1.0.0",
+  "description": "Static multilingual book template driven by Markdown and a JSON config",
+  "type": "module",
+  "scripts": {
+    "generate:sitemap": "node tools/generate-sitemap.mjs"
+  }
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://example.com/how-to-love/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/how-to-love/?lang=en&amp;chapter=introduction</loc>
+    <lastmod>2025-09-24T10:45:38.077Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/how-to-love/?lang=zh-cn&amp;chapter=introduction</loc>
+    <lastmod>2025-09-24T10:45:40.685Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/how-to-love/?lang=zh-tw&amp;chapter=introduction</loc>
+    <lastmod>2025-09-24T10:45:44.242Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/how-to-love/?lang=en&amp;chapter=writing-with-markdown</loc>
+    <lastmod>2025-09-24T10:45:47.914Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/how-to-love/?lang=zh-cn&amp;chapter=writing-with-markdown</loc>
+    <lastmod>2025-09-24T10:45:51.674Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/how-to-love/?lang=zh-tw&amp;chapter=writing-with-markdown</loc>
+    <lastmod>2025-09-24T10:45:54.734Z</lastmod>
+  </url>
+</urlset>

--- a/tools/generate-sitemap.mjs
+++ b/tools/generate-sitemap.mjs
@@ -1,0 +1,98 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const configPath = path.join(rootDir, 'config', 'site.config.json');
+
+async function main() {
+  const raw = await fs.readFile(configPath, 'utf8');
+  const config = JSON.parse(raw);
+  const baseUrl = normaliseBaseUrl(config.site?.baseUrl || '');
+
+  const urls = [];
+  for (const chapter of config.chapters || []) {
+    for (const language of config.languages || []) {
+      const fileName = chapter.files?.[language.code];
+      if (!fileName) continue;
+      const contentPath = path.join(rootDir, 'content', language.code, fileName);
+      let lastModified = new Date().toISOString();
+      try {
+        const stat = await fs.stat(contentPath);
+        const now = Date.now();
+        const safeTime = Math.min(stat.mtime.getTime(), now);
+        lastModified = new Date(safeTime).toISOString();
+      } catch (error) {
+        // Ignore missing files in sitemap output
+      }
+      const url = buildPageUrl(baseUrl, language.code, chapter.id);
+      urls.push({ url, lastModified });
+    }
+  }
+
+  const sitemap = buildSitemap(urls);
+  const sitemapPath = path.join(rootDir, 'sitemap.xml');
+  await fs.writeFile(sitemapPath, sitemap, 'utf8');
+  console.log(`Generated sitemap with ${urls.length} entries at ${relativePath(sitemapPath)}`);
+
+  const robots = buildRobotsTxt(baseUrl);
+  const robotsPath = path.join(rootDir, 'robots.txt');
+  await fs.writeFile(robotsPath, robots, 'utf8');
+  console.log(`Updated robots.txt at ${relativePath(robotsPath)}`);
+}
+
+function buildSitemap(urls) {
+  const items = urls
+    .map(
+      ({ url, lastModified }) => `  <url>\n    <loc>${escapeXml(url)}</loc>\n    <lastmod>${lastModified}</lastmod>\n  </url>`
+    )
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</urlset>\n`;
+}
+
+function buildRobotsTxt(baseUrl) {
+  const sitemapUrl = baseUrl ? new URL('sitemap.xml', baseUrl).toString() : 'sitemap.xml';
+  return [`User-agent: *`, `Allow: /`, '', `Sitemap: ${sitemapUrl}`, ''].join('\n');
+}
+
+function normaliseBaseUrl(url) {
+  if (!url) return '';
+  if (!/https?:\/\//i.test(url)) {
+    return url;
+  }
+  const normalised = url.endsWith('/') ? url : `${url}/`;
+  return normalised;
+}
+
+function buildPageUrl(baseUrl, language, chapterId) {
+  if (baseUrl && /https?:\/\//i.test(baseUrl)) {
+    const url = new URL(baseUrl);
+    url.searchParams.set('lang', language);
+    if (chapterId) {
+      url.searchParams.set('chapter', chapterId);
+    }
+    return url.toString();
+  }
+  const query = new URLSearchParams({ lang: language, chapter: chapterId }).toString();
+  return `${baseUrl.replace(/[#?].*$/, '') || '.'}?${query}`;
+}
+
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function relativePath(target) {
+  return path.relative(rootDir, target);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- replace the previous submodule with a configurable multilingual book template driven by a central JSON file
- add the HTML shell, styles, runtime script, and sample Markdown chapters that render the book UI at runtime
- generate SEO helpers (sitemap/robots) and document usage, configuration, and upgrade guidance in README and AGENTS docs

## Testing
- npm run generate:sitemap

------
https://chatgpt.com/codex/tasks/task_e_68d3cb331f48832bab0ac88b1aaf869f